### PR TITLE
Expand next peerDependency to include v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-seomatic",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Components and functions to use SEOmatic data in Next.js projects.",
   "repository": "git@github.com:joshuabaker/next-seomatic.git",
   "author": "Joshua Baker <160484+joshuabaker@users.noreply.github.com>",
@@ -16,7 +16,7 @@
     "prepublishOnly": "yarn build"
   },
   "peerDependencies": {
-    "next": ">= 13.4 < 15",
+    "next": "^13.4 || ^14",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prepublishOnly": "yarn build"
   },
   "peerDependencies": {
-    "next": "^13.4",
+    "next": ">= 13.4 < 15",
     "react": "^18",
     "react-dom": "^18"
   },


### PR DESCRIPTION
Thanks for this package! I was quite distressed after I found out about Next dropping <Head>, but this package saved the day :-)

It seems this works fine with Next 14 as well, how do you feel about updating its value in `peerDependencies`?