### PR TITLE
change prepublishOnly to prepare so package builds from git install

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --write .",
     "lint": "prettier --check . && eslint . --ext .ts,.tsx",
     "build": "tsc",
-    "prepublishOnly": "yarn build"
+    "prepare": "yarn build"
   },
   "peerDependencies": {
     "next": "^13.4",


### PR DESCRIPTION
This will build the package for people who install it bare from a Git repo, which could be handy if someone wants to fork it and install their fork to test something (like me).

I'm sure it's possible you had a reason to use `prepublishOnly`, just putting this here in case it's helpful.